### PR TITLE
Fix a bug where CO2 level was not correctly reported

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -25,6 +25,7 @@
     "max-len": ["warn", 140],
     "no-console": ["warn"], // use the provided Homebridge log method instead
     "no-non-null-assertion": ["off"],
+    "no-unused-expressions" : ["warn"],
     "comma-spacing": ["error"],
     "no-multi-spaces": ["warn", { "ignoreEOLComments": true }],
     "no-trailing-spaces": ["warn"],

--- a/src/platformAccessory.ts
+++ b/src/platformAccessory.ts
@@ -113,12 +113,12 @@ export class Aranet4Accessory {
 
       this.temperatureService.updateCharacteristic(this.platform.Characteristic.CurrentTemperature, data.temperature);
 
-      const level = this.platform.Characteristic.CarbonDioxideDetected.CO2_LEVELS_NORMAL;
+      let co2level = this.platform.Characteristic.CarbonDioxideDetected.CO2_LEVELS_NORMAL;
       if (data.co2 >= this.platform.config.co2AlertThreshold) {
-        this.platform.Characteristic.CarbonDioxideDetected.CO2_LEVELS_ABNORMAL;
+        co2level = this.platform.Characteristic.CarbonDioxideDetected.CO2_LEVELS_ABNORMAL;
       }
 
-      this.co2Service.updateCharacteristic(this.platform.Characteristic.CarbonDioxideDetected, level);
+      this.co2Service.updateCharacteristic(this.platform.Characteristic.CarbonDioxideDetected, co2level);
       this.co2Service.updateCharacteristic(this.platform.Characteristic.CarbonDioxideLevel, data.co2);
 
       this.platform.log.debug('Updated data:', data);


### PR DESCRIPTION
And add the `"no-unused-expressions"` `eslint` rule to prevent the same issue in the future.