### PR TITLE
Make `peripheral` property private to avoid circular structure

### DIFF
--- a/src/aranet.ts
+++ b/src/aranet.ts
@@ -45,11 +45,11 @@ export class Aranet4Device {
 
   public readonly info: Aranet4DeviceInfo;
 
-  private readonly peripheral: noble.Peripheral;
+  readonly #peripheral: noble.Peripheral;
 
   constructor(logger: Logger, peripheral: noble.Peripheral, info: Aranet4DeviceInfo) {
     this.logger = logger;
-    this.peripheral = peripheral;
+    this.#peripheral = peripheral;
     this.info = info;
   }
 
@@ -73,9 +73,9 @@ export class Aranet4Device {
   }
 
   async waitForPeripheral() {
-    if (this.peripheral.state !== 'connected') {
-      this.logger.debug('Connecting to', this.peripheral.uuid, ':', this.peripheral.state);
-      await this.peripheral.connectAsync();
+    if (this.#peripheral.state !== 'connected') {
+      this.logger.debug('Connecting to', this.#peripheral.uuid, ':', this.#peripheral.state);
+      await this.#peripheral.connectAsync();
     }
   }
 
@@ -152,9 +152,9 @@ export class Aranet4Device {
   async getSensorData(btReadyTimeout: number): Promise<AranetData> {
     await Aranet4Device.waitForBluetooth(this.logger, btReadyTimeout);
     await this.waitForPeripheral();
-    this.logger.debug('Connected to Aranet4', this.peripheral.uuid);
+    this.logger.debug('Connected to Aranet4', this.#peripheral.uuid);
 
-    const { characteristics } = await this.peripheral.discoverSomeServicesAndCharacteristicsAsync(
+    const { characteristics } = await this.#peripheral.discoverSomeServicesAndCharacteristicsAsync(
       [ARANET4_SERVICE], [ARANET4_CHARACTERISTICS],
     );
     if (characteristics.length === 0) {
@@ -172,7 +172,7 @@ export class Aranet4Device {
       'battery': data.readUInt8(7),
     };
 
-    await this.peripheral.disconnectAsync();
+    await this.#peripheral.disconnectAsync();
     return results;
   }
 }


### PR DESCRIPTION
`peripheral` is an object that eventually contains itself.
It's coming from the `noble` library so I don't have control over that.

This causes an issue when `JSON.stringify()` is called to save the accessory to disk.

Make the `peripheral` property private using [ECMAScript private field](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes/Private_class_fields) (instead of typescript's `private` keyword), as it will exclude `peripheral` from `JSON.stringify()`.

Fixes #11