### PR TITLE
Switch to new service UUID used in newest firmware

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ It uses Bluetooth 4 (Low Energy) to connect to the Aranet.
 
 It reports the CO2 level, humidity and temperature and the device's battery into HomeKit.
 
+It requires an Aranet device running at least the v1.2.0 firmware.
+
 It's very much in beta currently (I've only tested this with a single device, on macOS).
 If you run into problems, please open an issue.
 

--- a/src/aranet.ts
+++ b/src/aranet.ts
@@ -1,8 +1,8 @@
 import noble from '@abandonware/noble';
 import { TextDecoder } from 'util';
-import {Logger} from 'homebridge';
+import { Logger } from 'homebridge';
 
-const ARANET4_SERVICE = 'f0cd140095da4f4b9ac8aa55d312af0c';
+const ARANET4_SERVICE = '0000fce0-0000-1000-8000-00805f9b34fb';
 const ARANET4_CHARACTERISTICS = 'f0cd300195da4f4b9ac8aa55d312af0c';
 
 const MANUFACTURER_NAME = { name: 'org.bluetooth.characteristic.manufacturer_name_string', id: '2a29' };


### PR DESCRIPTION
See https://forum.aranet.com/all-about-aranet4/aranet4-with-firmware-v.1.2.0-or-greater-integration-notes/

Fixes #15