### PR TITLE
Remove `on('stateChange')` listener once poweredOn

### DIFF
--- a/src/aranet.ts
+++ b/src/aranet.ts
@@ -63,12 +63,15 @@ export class Aranet4Device {
         return resolve(true);
       }
 
-      noble.on('stateChange', async (state) => {
+      const stateChangeHandler = async (state) => {
         logger.debug(state);
         if (state === 'poweredOn') {
+          // Remove listener to avoid `Possible EventEmitter memory leak detected` warning
+          noble.removeListener('stateChange', stateChangeHandler);
           return resolve(true);
         }
-      });
+      };
+      noble.on('stateChange', stateChangeHandler);
     });
   }
 


### PR DESCRIPTION
Remove the listener so we start fresh each time and we try to avoid the
```
MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 stateChange listeners added to [Noble]. Use emitter.setMaxListeners() to increase limit
```
warning

Might help for #20